### PR TITLE
Fix invalid version property causing install to fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Streamkeys-Quantum",
-  "version": "1.7.6.1",
+  "version": "1.7.7",
   "description": "Global hotkeys for online music players including support for media keys.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
`npm install` fails if the version does not conform to `\d+\.\d+\.\d+`, so the current version string breaks the entire plugin.